### PR TITLE
ci: linter, type checker, and formatter

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -18,10 +18,14 @@ jobs:
         with:
           python-version: "3.11"
           cache: pipenv
+
       - name: Install pipenv
-        run: PIPENV_VENV_IN_PROJECT=true pipx run pipenv sync
+        run: pipx install pipenv
+      - name: Install dependencies
+        run: pipenv sync
       - name: Activate venv
-        run: echo "$PWD/.venv/bin" >> $GITHUB_PATH
+        run: echo "$(pipenv --venv --quiet)/bin" >> $GITHUB_PATH
+
       - uses: jakebailey/pyright-action@v1
         with:
           # CI: v1.1.346 produces strange undocumented error, pinning to .345 for now

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -29,7 +29,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Run Ruff
+      - name: Run Ruff linter
         run: pipx run ruff check --output-format github
 
-  # format: ...
+  format:
+    needs: ["pyright", "ruff"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Ruff
+        run: pipx install ruff
+      - name: Run isort
+        run: ruff check --select I --fix-only
+      - name: Run black
+        run: ruff format
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "style: black + isort"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -3,7 +3,7 @@ name: Python
 on:
   push:
     branches: ["master", "ci-test"]
-    paths: ["**/*.py"]
+    paths: ["Pipfile", "**/*.py"]
   pull_request:
     branches: ["master", "ci-test"]
     paths: ["**/*.py"]
@@ -22,6 +22,14 @@ jobs:
       - name: Activate venv
         run: echo "$PWD/.venv/bin" >> $GITHUB_PATH
       - uses: jakebailey/pyright-action@v1
+        with:
+          version: 1.1.311
 
-  # ruff: ...
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Ruff
+        run: pipx run ruff check --output-format github
+
   # format: ...

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   pyright:
+    name: Pyright
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -23,16 +24,20 @@ jobs:
         run: echo "$PWD/.venv/bin" >> $GITHUB_PATH
       - uses: jakebailey/pyright-action@v1
         with:
-          version: 1.1.311
+          # CI: v1.1.346 produces strange undocumented error, pinning to .345 for now
+          # | "ValitaError: missing_value at .generalDiagnostics.0.file (missing value)"
+          version: 1.1.345
 
   ruff:
+    name: Ruff
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Run Ruff linter
+      - name: Run Ruff
         run: pipx run ruff check --output-format github
 
-  format:
+  black:
+    name: Black
     needs: ["pyright", "ruff"]
     runs-on: ubuntu-latest
     steps:
@@ -41,7 +46,7 @@ jobs:
         run: pipx install ruff
       - name: Run isort
         run: ruff check --select I --fix-only
-      - name: Run black
+      - name: Run Black
         run: ruff format
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,27 @@
+name: Python
+
+on:
+  push:
+    branches: ["master", "ci-test"]
+    paths: ["**/*.py"]
+  pull_request:
+    branches: ["master", "ci-test"]
+    paths: ["**/*.py"]
+
+jobs:
+  pyright:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pipenv
+      - name: Install pipenv
+        run: PIPENV_VENV_IN_PROJECT=true pipx run pipenv sync
+      - name: Activate venv
+        run: echo "$PWD/.venv/bin" >> $GITHUB_PATH
+      - uses: jakebailey/pyright-action@v1
+
+  # ruff: ...
+  # format: ...

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -3,10 +3,10 @@ name: Python
 on:
   push:
     branches: ["master", "ci-test"]
-    paths: ["Pipfile", "**/*.py"]
+    paths: ["**/*.py", "Pipfile.lock", "pyproject.toml"]
   pull_request:
     branches: ["master", "ci-test"]
-    paths: ["**/*.py"]
+    paths: ["**/*.py", "Pipfile.lock", "pyproject.toml"]
 
 jobs:
   pyright:

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,8 +1,0 @@
-name: Ruff
-on: [push, pull_request]
-jobs:
-  ruff:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: chartboost/ruff-action@v1

--- a/Pipfile
+++ b/Pipfile
@@ -3,12 +3,12 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 name = "pypi"
 
+[requires]
+python_version = "3.11"
+
 [packages]
 discord = "~=2.3"
 jishaku = "~=2.5"
 
 [dev-packages]
 ruff = "*"
-
-[requires]
-python_version = "3.11"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -455,27 +455,27 @@
     "develop": {
         "ruff": {
             "hashes": [
-                "sha256:09c415716884950080921dd6237767e52e227e397e2008e2bed410117679975b",
-                "sha256:0f58948c6d212a6b8d41cd59e349751018797ce1727f961c2fa755ad6208ba45",
-                "sha256:190a566c8f766c37074d99640cd9ca3da11d8deae2deae7c9505e68a4a30f740",
-                "sha256:231d8fb11b2cc7c0366a326a66dafc6ad449d7fcdbc268497ee47e1334f66f77",
-                "sha256:4b077ce83f47dd6bea1991af08b140e8b8339f0ba8cb9b7a484c30ebab18a23f",
-                "sha256:5b25093dad3b055667730a9b491129c42d45e11cdb7043b702e97125bcec48a1",
-                "sha256:6464289bd67b2344d2a5d9158d5eb81025258f169e69a46b741b396ffb0cda95",
-                "sha256:934832f6ed9b34a7d5feea58972635c2039c7a3b434fe5ba2ce015064cb6e955",
-                "sha256:97ce4d752f964ba559c7023a86e5f8e97f026d511e48013987623915431c7ea9",
-                "sha256:9b8f397902f92bc2e70fb6bebfa2139008dc72ae5177e66c383fa5426cb0bf2c",
-                "sha256:9bd4025b9c5b429a48280785a2b71d479798a69f5c2919e7d274c5f4b32c3607",
-                "sha256:a7f772696b4cdc0a3b2e527fc3c7ccc41cdcb98f5c80fdd4f2b8c50eb1458196",
-                "sha256:c4a88efecec23c37b11076fe676e15c6cdb1271a38f2b415e381e87fe4517f18",
-                "sha256:e1ad00662305dcb1e987f5ec214d31f7d6a062cae3e74c1cbccef15afd96611d",
-                "sha256:ea0d3e950e394c4b332bcdd112aa566010a9f9c95814844a7468325290aabfd9",
-                "sha256:eb85ee287b11f901037a6683b2374bb0ec82928c5cbc984f575d0437979c521a",
-                "sha256:f9d4d88cb6eeb4dfe20f9f0519bd2eaba8119bde87c3d5065c541dbae2b5a2cb"
+                "sha256:226b517f42d59a543d6383cfe03cccf0091e3e0ed1b856c6824be03d2a75d3b6",
+                "sha256:2f59bcf5217c661254bd6bc42d65a6fd1a8b80c48763cb5c2293295babd945dd",
+                "sha256:5f0312ba1061e9b8c724e9a702d3c8621e3c6e6c2c9bd862550ab2951ac75c16",
+                "sha256:6bbbc3042075871ec17f28864808540a26f0f79a4478c357d3e3d2284e832998",
+                "sha256:7a36fa90eb12208272a858475ec43ac811ac37e91ef868759770b71bdabe27b6",
+                "sha256:9a1600942485c6e66119da294c6294856b5c86fd6df591ce293e4a4cc8e72989",
+                "sha256:9ebb40442f7b531e136d334ef0851412410061e65d61ca8ce90d894a094feb22",
+                "sha256:9fb6b3b86450d4ec6a6732f9f60c4406061b6851c4b29f944f8c9d91c3611c7a",
+                "sha256:a623349a505ff768dad6bd57087e2461be8db58305ebd5577bd0e98631f9ae69",
+                "sha256:b13ba5d7156daaf3fd08b6b993360a96060500aca7e307d95ecbc5bb47a69296",
+                "sha256:dcaab50e278ff497ee4d1fe69b29ca0a9a47cd954bb17963628fa417933c6eb1",
+                "sha256:e261f1baed6291f434ffb1d5c6bd8051d1c2a26958072d38dfbec39b3dda7352",
+                "sha256:e3fd36e0d48aeac672aa850045e784673449ce619afc12823ea7868fcc41d8ba",
+                "sha256:e6894b00495e00c27b6ba61af1fc666f17de6140345e5ef27dd6e08fb987259d",
+                "sha256:ee3febce7863e231a467f90e681d3d89210b900d49ce88723ce052c8761be8c7",
+                "sha256:f57de973de4edef3ad3044d6a50c02ad9fc2dff0d88587f25f1a48e3f72edf5e",
+                "sha256:f988746e3c3982bea7f824c8fa318ce7f538c4dfefec99cd09c8770bd33e6539"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==0.1.11"
+            "version": "==0.1.13"
         }
     }
 }

--- a/clockbot/check.py
+++ b/clockbot/check.py
@@ -11,7 +11,7 @@ def owner_or_permissions(**perms):
     bot owner or has_permissions
     """
     original = commands.has_permissions(**perms)
-    predicate = getattr(original, "predicate")
+    predicate = original.predicate
 
     async def extended_check(ctx: commands.Context):
         if not ctx.guild:

--- a/clockbot/converter.py
+++ b/clockbot/converter.py
@@ -98,6 +98,7 @@ def fuzzysearch(
 
     def sort_key(tup):
         return tup[1:]
+
     return [t[0] for t in sorted(suggestions, key=sort_key)]
 
 
@@ -235,6 +236,7 @@ class FuzzyMember(commands.MemberConverter, MemberType):
         # Found better method -> https://taegon.kim/archives/9919
 
         text = j2hcj(h2j(arg))
+
         def key(m):
             return j2hcj(h2j(m.display_name))
 

--- a/clockbot/converter.py
+++ b/clockbot/converter.py
@@ -158,11 +158,11 @@ class PartialMember(commands.MemberConverter, MemberType):
 
         try:
             answer = await ctx.bot.wait_for("message", check=check, timeout=20.0)
-        except asyncio.TimeoutError:
+        except asyncio.TimeoutError as e:
             embed = discord.Embed()
             embed.set_author(name="선택지 시간제한 초과")
             await question.edit(embed=embed)
-            raise NoProblemError
+            raise NoProblemError from e
 
         try:
             await answer.delete()

--- a/clockbot/core.py
+++ b/clockbot/core.py
@@ -87,6 +87,7 @@ def alias_as_arg(name: str | None = None, aliases: list[str] | None = None, **at
 
     if aliases is None:
         aliases = []
+
     def decorator(func):
         return AliasAsArg(func, name=name, aliases=aliases, **attrs)
 

--- a/clockbot/core.py
+++ b/clockbot/core.py
@@ -4,7 +4,7 @@ from typing import TypeVar
 from discord.ext import commands
 
 # hooked_wrapped_callback = commands.core.hooked_wrapped_callback
-hooked_wrapped_callback = getattr(commands.core, "hooked_wrapped_callback")
+hooked_wrapped_callback = commands.core.hooked_wrapped_callback
 
 __all__ = (
     "Command",
@@ -80,11 +80,13 @@ def command(
     return decorator
 
 
-def alias_as_arg(name: str | None = None, aliases: list[str] = [], **attrs):
+def alias_as_arg(name: str | None = None, aliases: list[str] | None = None, **attrs):
     """
     Decorator for AliasAsArg command.
     """
 
+    if aliases is None:
+        aliases = []
     def decorator(func):
         return AliasAsArg(func, name=name, aliases=aliases, **attrs)
 

--- a/clockbot/help/embedhelp.py
+++ b/clockbot/help/embedhelp.py
@@ -24,16 +24,22 @@ class EmbedHelp(commands.HelpCommand):
     def __init__(
         self,
         *,
-        command_attrs={},
+        command_attrs=None,
         color: int = 0xFFFFFF,
         title: str = "Sample Text",
         invite: str = "https://youtu.be/dQw4w9WgXcQ",
         contact: str = "안받음",
         thumbnail: str | None = None,
-        menu: list[str] = [],
-        tips: list[str] = [],
+        menu: list[str] = None,
+        tips: list[str] = None,
         **options,
     ):
+        if tips is None:
+            tips = []
+        if menu is None:
+            menu = []
+        if command_attrs is None:
+            command_attrs = {}
         super().__init__(command_attrs=command_attrs, **options)
         self.color = color
         self.title = title

--- a/clockbot/help/texthelp.py
+++ b/clockbot/help/texthelp.py
@@ -63,8 +63,10 @@ class TextHelp(commands.HelpCommand):
     context: commands.Context
 
     def __init__(
-        self, prefix: str = "", suffix: str = "", cogs: list[str] = [], **options
+        self, prefix: str = "", suffix: str = "", cogs: list[str] = None, **options
     ):
+        if cogs is None:
+            cogs = []
         super().__init__(**options)
         self.name = options["command_attrs"]["name"]
         self.page = TextPage()  # why not just create new page per sending

--- a/main.py
+++ b/main.py
@@ -63,7 +63,3 @@ if __name__ == "__main__":
         logging.critical("Unhandled Exception has occured", exc_info=True)
     finally:
         logging.info("Client terminated")
-
-
-
-

--- a/main.py
+++ b/main.py
@@ -63,5 +63,3 @@ if __name__ == "__main__":
         logging.critical("Unhandled Exception has occured", exc_info=True)
     finally:
         logging.info("Client terminated")
-
-a: int = "Making pyright angry to test CI"

--- a/main.py
+++ b/main.py
@@ -63,3 +63,7 @@ if __name__ == "__main__":
         logging.critical("Unhandled Exception has occured", exc_info=True)
     finally:
         logging.info("Client terminated")
+
+
+
+

--- a/main.py
+++ b/main.py
@@ -63,3 +63,5 @@ if __name__ == "__main__":
         logging.critical("Unhandled Exception has occured", exc_info=True)
     finally:
         logging.info("Client terminated")
+
+a: int = "Intentionally pissing off Pyright to test CI"

--- a/main.py
+++ b/main.py
@@ -64,4 +64,4 @@ if __name__ == "__main__":
     finally:
         logging.info("Client terminated")
 
-a: int = "Intentionally pissing off Pyright to test CI"
+a: int = "Making pyright angry to test CI"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ output-format = "grouped"
 extend-exclude = ["cogs/legacy", "cogs/aprilfools"]
 
 # TODO: browse and enable more opt-in rules
-select = ["E4", "E7", "E9", "F", "I", "N"]
+select = ["E4", "E7", "E9", "F", "N", "B"]
 
 # F403: checks for wildcard imports (`from module import *`)
 # excuse: I will always be using * with modules with `__all__`

--- a/utils/MemberFilter.py
+++ b/utils/MemberFilter.py
@@ -147,6 +147,6 @@ def parse(expression: str, guild: discord.Guild) -> set[discord.Member]:
     lexer.quotes += "`"
     try:
         tokens = list(lexer)
-    except ValueError:
-        raise SyntaxError("Unclosed quote", '"')
+    except ValueError as e:
+        raise SyntaxError("Unclosed quote", '"') from e
     return parse_tokens(tokens, guild)


### PR DESCRIPTION
Based on the original plans at WieeRd/ricecake#2.
Things are working smoothly, but there is still room for improvements.

- Pyright v1.1.346 produces undocumented error. Had to pin the version to .345
- `pipenv` and `ruff` are installed via `pipx`, and they are not cached.

The problematic version was released 2 hours ago, so there is not much I can do for now.
And the whole workflow takes less than a minute even without caching `pipx`.

LGTM.